### PR TITLE
fix CSC, diagonal multiplication

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -170,14 +170,10 @@ function mul!(Y::SparseMatrixCSC, X::SparseMatrixCSC, A::Diagonal{T,Vector{T}}) 
     nA = size(A, 1)
     mX, nX = size(X)
     nX == nA || throw(DimensionMismatch())
-    j = 1
-    va = A.diag[1]
-    @inbounds for k = 1:nnz(X)
-        if k == X.colptr[j]
-            va = A.diag[j]
-            j = j + 1
+    @inbounds for j = 1:nA
+        for k = X.colptr[j]:X.colptr[j+1]-1
+            Y.nzval[k] *= A.diag[j]
         end
-        Y.nzval[k] *= va
     end
     Y
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -128,3 +128,9 @@ end
     sp = sprand(512, 512, 0.05)
     @test nnz(pm * sp - SparseMatrixCSC(pm) * sp) == 0
 end
+
+@testset "regression test" begin
+    pop = sparse([2, 3], [4, 5], [1, √2], 5, 5)
+    zop = Diagonal([0, 1/2, 1, -1/2, 0])
+    @test (pop * zop)[2,4] == -0.5
+end


### PR DESCRIPTION
## Previous
```julia
julia> using SparseArrays, LinearAlgebra
​
julia> pop = sparse([2, 3], [4, 5], [1, √2], 5, 5)
5×5 SparseMatrixCSC{Float64,Int64} with 2 stored entries:
  [2, 4]  =  1.0
  [3, 5]  =  1.41421
​
julia> zop = Diagonal([0, 1/2, 1, -1/2, 0])
5×5 Diagonal{Float64,Array{Float64,1}}:
 0.0   ⋅    ⋅     ⋅    ⋅ 
  ⋅   0.5   ⋅     ⋅    ⋅ 
  ⋅    ⋅   1.0    ⋅    ⋅ 
  ⋅    ⋅    ⋅   -0.5   ⋅ 
  ⋅    ⋅    ⋅     ⋅   0.0
​
julia> pop * zop
5×5 SparseMatrixCSC{Float64,Int64} with 2 stored entries:
  [2, 4]  =  -0.5
  [3, 5]  =  0.0
​
julia> using RydbergPulse
[ Info: Precompiling RydbergPulse [8e30c046-55fb-45d0-b9a3-7d9125e1d9de]
​
julia> pop * zop
5×5 SparseMatrixCSC{Float64,Int64} with 2 stored entries:
  [2, 4]  =  0.0
  [3, 5]  =  0.0
```

Now this is fixed.

## Benchmarks 
```julia
julia> using SparseArrays

julia> using LinearAlgebra

julia> pop2 = sprand(1000, 1000, 0.001);

julia> zop2 = Diagonal(randn(1000));

julia> using BenchmarkTools

julia> @benchmark $pop2 * $zop2
BenchmarkTools.Trial: 
  memory estimate:  24.75 KiB
  allocs estimate:  3
  --------------
  minimum time:     4.156 μs (0.00% GC)
  median time:      4.947 μs (0.00% GC)
  mean time:        5.352 μs (5.37% GC)
  maximum time:     91.504 μs (91.76% GC)
  --------------
  samples:          10000
  evals/sample:     7

julia> using LuxurySparse

julia> @benchmark $pop2 * $zop2
BenchmarkTools.Trial: 
  memory estimate:  24.75 KiB
  allocs estimate:  3
  --------------
  minimum time:     3.528 μs (0.00% GC)
  median time:      4.332 μs (0.00% GC)
  mean time:        4.654 μs (5.59% GC)
  maximum time:     131.605 μs (88.55% GC)
  --------------
  samples:          10000
  evals/sample:     7
```
