### PR TITLE
fix coo with Cint

### DIFF
--- a/src/SparseMatrixCOO.jl
+++ b/src/SparseMatrixCOO.jl
@@ -81,7 +81,7 @@ function allocated_coo(::Type{T}, M::Int, N::Int, nnz::Int) where {T}
     SparseMatrixCOO{T}(undef, M, N, nnz)
 end
 
-function getindex(coo::SparseMatrixCOO{Tv,Ti}, i::Ti, j::Ti) where {Tv,Ti}
+function getindex(coo::SparseMatrixCOO{Tv,Ti}, i::Integer, j::Integer) where {Tv,Ti}
     res = zero(Tv)
     for k = 1:nnz(coo)
         if coo.is[k] == i && coo.js[k] == j
@@ -110,8 +110,8 @@ isdense(::SparseMatrixCOO) = false
 Base.@propagate_inbounds function Base.setindex!(
     coo::SparseMatrixCOO{Tv,Ti},
     v,
-    i::Ti,
-    j::Ti,
+    i::Integer,
+    j::Integer,
 ) where {Tv,Ti}
     @boundscheck (1 <= i <= coo.m) && (1 <= j <= coo.n) || throw(BoundsError(coo, (i, j)))
 

--- a/test/SparseMatrixCOO.jl
+++ b/test/SparseMatrixCOO.jl
@@ -52,4 +52,8 @@ end
     @test coo.is[end] == 1
     @test coo.js[end] == 1
     @test coo.vs[end] == 0.2
+
+    S = SparseMatrixCOO{Float32, Cint}(Cint[], Cint[], Float32[], 5, 5)
+    S[1, 1] = 3
+    @test S[1, 1] == 3
 end


### PR DESCRIPTION
e.g `getindex` and `setindex!` wasn't working on `SparseMatrixCOO{Float32, Cint}`, but `Cint` is the required index type for several sparse lib wrappers such as MKLSparse and CUSPARSE