### PR TITLE
overload mul for PermMatrix

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -45,14 +45,12 @@ end
 
 ########## Multiplication #############
 
-# NOTE: making them dry?
-# to vector
-function LinearAlgebra.mul!(Y::AbstractVector, A::PermMatrix, X::AbstractVector)
+function LinearAlgebra.mul!(Y::AbstractVector, A::PermMatrix, X::AbstractVector, alpha::Number, beta::Number)
     length(X) == size(A, 2) || throw(DimensionMismatch("input X length does not match PermMatrix A"))
     length(Y) == size(A, 2) || throw(DimensionMismatch("output Y length does not match PermMatrix A"))
 
     @inbounds for I in eachindex(X)
-        Y[I] = A.vals[I] * X[A.perm[I]]
+        Y[I] = A.vals[I] * X[A.perm[I]] * alpha + beta * Y[I]
     end
     return Y
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -47,24 +47,14 @@ end
 
 # NOTE: making them dry?
 # to vector
-function *(A::PermMatrix{Ta}, X::AbstractVector{Tx}) where {Ta,Tx}
-    nX = length(X)
-    nX == size(A, 2) || throw(DimensionMismatch())
-    v = similar(X, promote_type(Ta, Tx))
-    @simd for i = 1:nX
-        @inbounds v[i] = A.vals[i] * X[A.perm[i]]
-    end
-    v
-end
+function LinearAlgebra.mul!(Y::AbstractVector, A::PermMatrix, X::AbstractVector)
+    length(X) == size(A, 2) || throw(DimensionMismatch("input X length does not match PermMatrix A"))
+    length(Y) == size(A, 2) || throw(DimensionMismatch("output Y length does not match PermMatrix A"))
 
-function *(X::Adjoint{Tx,<:AbstractVector{Tx}}, A::PermMatrix{Ta}) where {Tx,Ta}
-    nX = length(X)
-    nX == size(A, 1) || throw(DimensionMismatch())
-    v = similar(X, promote_type(Tx, Ta))
-    @simd for i = 1:nX
-        @inbounds v[A.perm[i]] = A.vals[i] * X[i]
+    @inbounds for I in eachindex(X)
+        Y[I] = A.vals[I] * X[A.perm[I]]
     end
-    v
+    return Y
 end
 
 # to diagonal

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -11,21 +11,18 @@ v = [0.5, 0.3im, 0.2, 1.0]
 dv = Diagonal(v)
 
 
-@testset "kron" begin
-    for source in [p1, sp, ds, dv, pm]
-        for target in [p1, sp, ds, dv, pm]
-            lres = kron(source, target)
-            rres = kron(target, source)
-            flres = kron(Matrix(source), Matrix(target))
-            frres = kron(Matrix(target), Matrix(source))
-            @test lres == flres
-            @test rres == frres
-            @test eltype(lres) == eltype(flres)
-            @test eltype(rres) == eltype(frres)
-            if !(target === ds && source === ds)
-                @test !(typeof(lres) <: StridedMatrix)
-                @test !(typeof(rres) <: StridedMatrix)
-            end
-        end
+@testset "kron(::$(typeof(source)), ::$(typeof(target)))" for source in [p1, sp, ds, dv, pm],
+                                      target in [p1, sp, ds, dv, pm]
+    lres = kron(source, target)
+    rres = kron(target, source)
+    flres = kron(Matrix(source), Matrix(target))
+    frres = kron(Matrix(target), Matrix(source))
+    @test lres == flres
+    @test rres == frres
+    @test eltype(lres) == eltype(flres)
+    @test eltype(rres) == eltype(frres)
+    if !(target === ds && source === ds)
+        @test !(typeof(lres) <: StridedMatrix)
+        @test !(typeof(rres) <: StridedMatrix)
     end
 end


### PR DESCRIPTION
not necessary to overload * twice

Before

```julia
julia> @benchmark $H * $X
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   90.942 μs …  1.097 ms  ┊ GC (min … max): 0.00% … 78.45%
 Time  (median):      97.175 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   104.297 μs ± 54.600 μs  ┊ GC (mean ± σ):  3.66% ±  6.46%

  ▂▇█▆▅▄▂▁▁▁                                                   ▂
  ███████████▆▆▆▅▃▁▄▁▄▃▁▁▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▃▃▅▇███ █
  90.9 μs       Histogram: log(frequency) by time       233 μs <

 Memory estimate: 256.05 KiB, allocs estimate: 2.
```

After

```
julia> @benchmark $H * $X
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   87.427 μs …  1.272 ms  ┊ GC (min … max): 0.00% … 81.04%
 Time  (median):     100.521 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   108.521 μs ± 67.480 μs  ┊ GC (mean ± σ):  4.46% ±  6.63%

    ▃▆██▇▇▃▂▁▁                                              ▁▁ ▂
  ▃█████████████▇▇▇▆▆▄▆▇▄▄▁▅▄▄▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▇██ █
  87.4 μs       Histogram: log(frequency) by time       233 μs <

 Memory estimate: 256.05 KiB, allocs estimate: 2.

```
