### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/PermMatrix.jl
+++ b/src/PermMatrix.jl
@@ -159,7 +159,7 @@ function Base.show(io::IO, M::AbstractPermMatrix)
         end
     end
 end
-Base.hash(pm::AbstractPermMatrix) = hash((pm.perm, pm.vals))
+Base.hash(pm::AbstractPermMatrix, h::UInt) = hash((pm.perm, pm.vals), h)
 
 ######### sparse array interfaces  #########
 SparseArrays.nnz(M::AbstractPermMatrix) = length(M.vals)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.