### PR TITLE
Add Base.one and Base.zero where sensibly defined

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxurySparse"
 uuid = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
 authors = ["GiggleLiu <cacate0129@gmail.com>", "Roger-luo <hiroger@qq.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/IMatrix.jl
+++ b/src/IMatrix.jl
@@ -38,6 +38,7 @@ Base.:(==)(d1::IMatrix, d2::IMatrix) = d1.n == d2.n
 Base.isapprox(d1::IMatrix, d2::IMatrix; kwargs...) = d1 == d2
 
 Base.similar(A::IMatrix{Tv}, ::Type{T}) where {Tv,T} = IMatrix{T}(A.n)
+Base.one(A::IMatrix{T}) where {T} = IMatrix{T}(A.n)
 function Base.copyto!(A::IMatrix, B::IMatrix)
     if A.n != B.n
         throw(DimensionMismatch("matrix dimension mismatch, got $(A.n) and $(B.n)"))

--- a/src/PermMatrix.jl
+++ b/src/PermMatrix.jl
@@ -96,6 +96,8 @@ for MT in [:PermMatrix, :PermMatrixCSC]
     end
 end
 Base.zero(pm::AbstractPermMatrix) = basetype(pm)(pm.perm, zero(pm.vals))
+Base.one(pm::AbstractPermMatrix) =
+    basetype(pm)(typeof(pm.perm)(1:length(pm.perm)), one.(pm.vals))
 Base.similar(x::AbstractPermMatrix{Tv,Ti}) where {Tv,Ti} =
     typeof(x)(copy(x.perm), similar(x.vals))
 Base.similar(x::AbstractPermMatrix{Tv,Ti}, ::Type{T}) where {Tv,Ti,T} =

--- a/test/IMatrix.jl
+++ b/test/IMatrix.jl
@@ -65,6 +65,12 @@ end
     @test p1 / 2.0 == Matrix(p1) / 2.0
 end
 
+@testset "one" begin
+    @test one(IMatrix(4)) === IMatrix{Bool}(4)
+    @test one(IMatrix{Float64}(4)) === IMatrix{Float64}(4)
+    @test Matrix(one(IMatrix{Float64}(4))) == Matrix{Float64}(I, 4, 4)
+end
+
 @testset "push coverage" begin
     @test SparseMatrixCSC(IMatrix(3)) ≈ Diagonal(ones(3))
     @test Diagonal(IMatrix(3)) ≈ Diagonal(ones(3))

--- a/test/PermMatrix.jl
+++ b/test/PermMatrix.jl
@@ -78,6 +78,16 @@ end
     @test v == [0.5, 0.3im, 0.2, 1.0]
 end
 
+@testset "one and zero" begin
+    z = zero(p1)
+    @test typeof(z) == typeof(p1)
+    @test Matrix(z) == zeros(ComplexF64, 4, 4)
+
+    o = one(p1)
+    @test typeof(o) == typeof(p1)
+    @test Matrix(o) == Matrix{ComplexF64}(I, 4, 4)
+end
+
 @testset "sparse" begin
     Random.seed!(2)
     pm = pmrand(10)

--- a/test/PermMatrixCSC.jl
+++ b/test/PermMatrixCSC.jl
@@ -80,6 +80,16 @@ end
     @test v == [0.5, 0.3im, 0.2, 1.0]
 end
 
+@testset "one and zero" begin
+    z = zero(p1)
+    @test typeof(z) == typeof(p1)
+    @test Matrix(z) == zeros(ComplexF64, 4, 4)
+
+    o = one(p1)
+    @test typeof(o) == typeof(p1)
+    @test Matrix(o) == Matrix{ComplexF64}(I, 4, 4)
+end
+
 @testset "sparse" begin
     Random.seed!(2)
     pm = pmrand(10)

--- a/test/staticize.jl
+++ b/test/staticize.jl
@@ -91,3 +91,17 @@ Random.seed!(2)
     m = rand(2, 2)
     @test dynamicize(m) === m
 end
+
+@testset "one/zero preserve static containers" begin
+    for m in (staticize(pmrand(ComplexF64, 4)), staticize(pmcscrand(ComplexF64, 4)))
+        o = one(m)
+        @test o.perm isa SVector
+        @test o.vals isa SVector
+        @test Matrix(o) == Matrix{ComplexF64}(I, 4, 4)
+
+        z = zero(m)
+        @test z.perm isa SVector
+        @test z.vals isa SVector
+        @test Matrix(z) == zeros(ComplexF64, 4, 4)
+    end
+end


### PR DESCRIPTION
## Summary

Adds `Base.one` methods to the matrix types where the identity is representable in the type itself, so that generic code calling `one(A)` returns a specialized matrix of the same type instead of falling back to a dense/allocating result.

- `IMatrix` — `one(A::IMatrix{T}) = IMatrix{T}(A.n)`.
- `PermMatrix` / `PermMatrixCSC` (`AbstractPermMatrix`) — `one(pm)`

Types deliberately left untouched:
- `Base.zero(::AbstractPermMatrix)` already existed.
- `IMatrix` has no `zero` — a zero matrix isn't representable as an `IMatrix`.
- `SparseMatrixCOO` and `SSparseMatrixCSC` are rectangular (so `one` is ill-defined), and the COO docstring explicitly discourages arithmetic use.

Also bumps the version to 0.8.2.