### PR TITLE
Fix PermMatrixCSC test imports

### DIFF
--- a/test/PermMatrixCSC.jl
+++ b/test/PermMatrixCSC.jl
@@ -1,7 +1,7 @@
 using Test, Random
-import LuxurySparse: PermMatrixCSC, pmcscrand
+import LuxurySparse: IterNz, PermMatrix, PermMatrixCSC, pmcscrand, pmrand
 import LuxurySparse
-using SparseArrays: sprand, SparseMatrixCSC
+using SparseArrays: findnz, sprand, SparseMatrixCSC
 using LinearAlgebra
 
 Random.seed!(2)


### PR DESCRIPTION
## Summary
- Import the `PermMatrixCSC` test dependencies explicitly so the file can run standalone.
- Remove the unused `staticize` import from that test file.

## Test Plan
- [x] `julia --project=. test/PermMatrixCSC.jl`
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'`